### PR TITLE
fix: correct typo 'occured' -> 'occurred' in error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let model = match model_file.to_mesh3d() {
         Ok(model) => model,
         Err(e) => {
-            eprintln!("An error occured while converting the parsed file: {e}");
+            eprintln!("An error occurred while converting the parsed file: {e}");
             process::exit(1);
         }
     };


### PR DESCRIPTION
## Summary
Fix typo `occured` → `occurred` in user-facing error message in `src/main.rs`:

```rust
eprintln!("An error occured while converting the parsed file: {e}");
```
→
```rust
eprintln!("An error occurred while converting the parsed file: {e}");
```

Minimal fix: 1 file, 1 line change.