### PR TITLE
fix: correct occured→occurred typo in error message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let model = match model_file.to_mesh3d() {
         Ok(model) => model,
         Err(e) => {
-            eprintln!("An error occured while converting the parsed file: {e}");
+            eprintln!("An error occurred while converting the parsed file: {e}");
             process::exit(1);
         }
     };


### PR DESCRIPTION
Corrects the typo `occured` → `occurred` in the error message when file conversion fails (src/main.rs:33).

This is a user-facing error message in the CLI output.